### PR TITLE
Release 0.4.2

### DIFF
--- a/assembly_finder/assembly_finder.py
+++ b/assembly_finder/assembly_finder.py
@@ -145,7 +145,7 @@ CONTEXT_SETTINGS = {
     "--exclude",
     type=str,
     help="filter to exclude assemblies (example: exclude from metagenomes)",
-    default="metagenome",
+    default="anomalous",
     show_default=True,
 )
 @click.option(

--- a/assembly_finder/assembly_finder.py
+++ b/assembly_finder/assembly_finder.py
@@ -5,7 +5,6 @@ import os
 import sys
 import click
 import subprocess
-import datetime
 
 
 logging.basicConfig(
@@ -79,7 +78,7 @@ CONTEXT_SETTINGS = {
     default="assembly_report.txt,genomic.fna.gz",
     show_default=True,
 )
-@click.option("-o", "--outdir", help="output directory", type=str)
+@click.option("-o", "--outdir", help="output directory", type=click.Path())
 @click.option(
     "-n",
     "--dryrun_status",
@@ -206,8 +205,10 @@ def cli(
     ete_db,
     snakemake_args,
 ):
-    if not outdir:
-        outdir = datetime.datetime.today().strftime("%Y-%m-%d")
+    if outdir:
+        outdir = os.path.abspath(outdir)
+    else:
+        outdir = os.path.abspath(os.path.basename(input).split(".")[0])
 
     if dryrun_status:
         dryrun = "-n"

--- a/assembly_finder/bin/find_assemblies.smk
+++ b/assembly_finder/bin/find_assemblies.smk
@@ -264,12 +264,15 @@ rule get_summaries:
         seq_report = pd.read_csv(input.seq_report, sep="\t")
         # replace ftp paths with absolute paths
         try:
-            df.ftp_path = [
-                os.path.abspath(glob.glob(f"{params.asmdir}/{acc}*.fna.gz")[0])
-                for acc in df["asm_accession"]
-            ]
+            paths = []
+            for ftp in df["ftp_path"]:
+                acc = ftp.split("/")[-1]
+                path = os.path.abspath(glob.glob(f"{params.asmdir}/{acc}*.fna.gz")[0])
+                paths.append(path)
+            df["path"] = paths
+
         except IndexError:
-            df.ftp_path = df.ftp_path
+            df["path"] = df.ftp_path
 
         df.rename(columns={"ftp_path": "path"}, inplace=True)
         dfs = [df, asm_report, seq_report]

--- a/assembly_finder/bin/find_assemblies.smk
+++ b/assembly_finder/bin/find_assemblies.smk
@@ -172,7 +172,7 @@ checkpoint download_assemblies:
     input:
         os.path.join(outdir, "assemblies", "ftp-links.txt"),
     output:
-        os.path.join(outdir, "assemblies", "checksums.txt"),
+        temp(os.path.join(outdir, "assemblies", "checksums.txt")),
     log:
         os.path.join(outdir, "logs", "download.log"),
     params:
@@ -347,7 +347,7 @@ rule format_checksum:
     input:
         os.path.join(outdir, "assemblies", "checksums.txt"),
     output:
-        os.path.join(outdir, "assemblies", "aspera-checks.txt"),
+        temp(os.path.join(outdir, "assemblies", "aspera-checks.txt")),
     run:
         d = {
             line.replace('"', "")
@@ -377,7 +377,7 @@ rule verify_checksums:
         os.path.join(outdir, "assemblies", "aspera-checks.txt"),
         lambda wildcards: downloads(wildcards, sfxs),
     output:
-        os.path.join(outdir, "assemblies", "sha256.txt"),
+        temp(os.path.join(outdir, "assemblies", "sha256.txt")),
     params:
         lambda wildcards: get_ext(wildcards, asmdir, sfxs),
     shell:


### PR DESCRIPTION
Small release to fix genbank paths and checksum verification

`Changes`
* a98eacd5083c87ec501279ebb06fb61c675ea374 Changed default exclude to anomalous
* 25264d8aea11fa64cee7d009dd783f5fd46ae222 Use python os.path for rule paths
* f9307883959a6b52f9a120a20322d96218161398 Changed default outdir 

`Fixes`
* fedcb6f859e91608907fe74d0ce2486edeb310d5 fixes absolute paths when downloading from genbank
* 25264d8aea11fa64cee7d009dd783f5fd46ae222 fixes #9 