### PR TITLE
Add option to only download summary tables

### DIFF
--- a/assembly_finder/__main__.py
+++ b/assembly_finder/__main__.py
@@ -71,7 +71,11 @@ def common_options(func):
             help="Custom config file [default: (outputDir)/config.yaml]",
         ),
         click.option(
-            "--threads", help="Number of threads to use", default=1, show_default=True
+            "--threads",
+            "-t",
+            help="Number of threads to use",
+            default=1,
+            show_default=True,
         ),
         click.option(
             "--profile",
@@ -129,11 +133,11 @@ click.rich_click.OPTION_GROUPS = {
             "name": "Options",
             "options": [
                 "--input",
-                "--summary",
                 "--output",
-                "--taxonkit",
                 "--threads",
+                "--taxonkit",
                 "--taxon",
+                "--summary",
                 "--rank",
                 "--nrank",
                 "--print-versions",
@@ -208,7 +212,7 @@ CONTEXT_SETTINGS = {
 @click.option(
     "--summary/--all",
     type=bool,
-    help="Download all files or only summary tables",
+    help="Download only summary tables or all files",
     default=False,
     show_default=True,
 )
@@ -236,7 +240,7 @@ CONTEXT_SETTINGS = {
 )
 @click.option(
     "--taxon/--accession",
-    help="Are queries taxa names or accession",
+    help="Type of queries",
     type=bool,
     default=True,
     show_default=True,

--- a/assembly_finder/__main__.py
+++ b/assembly_finder/__main__.py
@@ -129,6 +129,7 @@ click.rich_click.OPTION_GROUPS = {
             "name": "Options",
             "options": [
                 "--input",
+                "--summary",
                 "--output",
                 "--taxonkit",
                 "--threads",
@@ -203,6 +204,13 @@ CONTEXT_SETTINGS = {
     help="Limit number of genomes per query",
     type=str,
     default=None,
+)
+@click.option(
+    "--summary/--all",
+    type=bool,
+    help="Download all files or only summary tables",
+    default=False,
+    show_default=True,
 )
 @click.option("--api-key", type=str, help="NCBI api-key", default=None)
 @click.option(

--- a/assembly_finder/__main__.py
+++ b/assembly_finder/__main__.py
@@ -224,7 +224,7 @@ CONTEXT_SETTINGS = {
     "--include",
     type=str,
     help="Comma seperated files to download : genome,rna,protein,cds,gff3,gtf,gbff,seq-report",
-    default="genome,seq-report",
+    default="genome",
     show_default=True,
 )
 @click.option(

--- a/assembly_finder/workflow/Snakefile
+++ b/assembly_finder/workflow/Snakefile
@@ -49,10 +49,6 @@ SOURCE = config.args.source
 SUMMARY = config.args.summary
 INCLUDE = config.args.include
 INCLUDE_LIST = INCLUDE.split(",")
-if "genome" not in INCLUDE_LIST or "seq-report" not in INCLUDE_LIST:
-    INCLUDE_LIST = ["genome", "seq-report"] + INCLUDE_LIST
-    INCLUDE = ",".join(INCLUDE_LIST)
-
 TAXON = config.args.taxon
 REFERENCE = config.args.reference
 ASM_LVL = config.args.assembly_level
@@ -72,7 +68,6 @@ include: os.path.join("rules", "download.smk")
 
 targets = [
     os.path.join(dir.out.base, "assembly_summary.tsv"),
-    os.path.join(dir.out.base, "sequence_report.tsv"),
     os.path.join(dir.out.base, "taxonomy.tsv"),
     os.path.join(dir.out.base, "cleanup.flag"),
 ]

--- a/assembly_finder/workflow/Snakefile
+++ b/assembly_finder/workflow/Snakefile
@@ -46,6 +46,7 @@ API_KEY = config.args.api_key
 LIMIT = config.args.limit
 COMPRESSED = config.args.compressed
 SOURCE = config.args.source
+SUMMARY = config.args.summary
 INCLUDE = config.args.include
 INCLUDE_LIST = INCLUDE.split(",")
 if "genome" not in INCLUDE_LIST or "seq-report" not in INCLUDE_LIST:
@@ -75,6 +76,12 @@ targets = [
     os.path.join(dir.out.base, "taxonomy.tsv"),
     os.path.join(dir.out.base, "cleanup.flag"),
 ]
+if SUMMARY:
+    targets = [
+        os.path.join(dir.out.base, "taxonomy.tsv"),
+        os.path.join(dir.out.base, "assembly_summary.tsv"),
+        os.path.join(dir.out.base, "accessions.txt"),
+    ]
 
 if PRINT_VERSIONS:
 

--- a/assembly_finder/workflow/envs/datasets.yml
+++ b/assembly_finder/workflow/envs/datasets.yml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - ncbi-datasets-cli =16.31.0
+  - ncbi-datasets-cli =16.32.0

--- a/assembly_finder/workflow/rules/download.smk
+++ b/assembly_finder/workflow/rules/download.smk
@@ -166,12 +166,18 @@ rule format_taxonkit_lineage:
         """
 
 
+if SUMMARY:
+    asm_table = os.path.join(dir.out.base, "assembly_summary.tsv")
+else:
+    asm_table = temp(os.path.join(dir.out.base, "assembly_summary.txt"))
+
+
 rule filter_genome_summaries:
     input:
         summary=os.path.join(dir.out.base, "genome_summaries.json"),
         lineage=os.path.join(dir.out.base, "lineage.tsv"),
     output:
-        gen=temp(os.path.join(dir.out.base, "assembly_summary.txt")),
+        gen=asm_table,
         tax=os.path.join(dir.out.base, "taxonomy.tsv"),
         acc=temp(os.path.join(dir.out.base, "accessions.txt")),
     params:

--- a/assembly_finder/workflow/rules/download.smk
+++ b/assembly_finder/workflow/rules/download.smk
@@ -266,21 +266,6 @@ rule copy_files:
         """
 
 
-rule cat_sequence_reports:
-    input:
-        os.path.join(dir.out.download),
-    output:
-        os.path.join(dir.out.base, "sequence_report.tsv"),
-    params:
-        jsonl=os.path.join(dir.out.base, "download", "*", "sequence_report.jsonl"),
-    conda:
-        os.path.join(dir.env, "datasets.yml")
-    shell:
-        """
-        cat {params.jsonl} | dataformat tsv genome-seq > {output}
-        """
-
-
 rule add_genome_paths:
     input:
         dir=os.path.join(dir.out.download),
@@ -299,7 +284,6 @@ rule cleanup_files:
     input:
         os.path.join(dir.out.base, "archive"),
         os.path.join(dir.out.base, "assembly_summary.tsv"),
-        os.path.join(dir.out.base, "sequence_report.tsv"),
         os.path.join(dir.out.base, "taxonomy.tsv"),
     output:
         temp(os.path.join(dir.out.base, "cleanup.flag")),


### PR DESCRIPTION
## Features
* 5f10c04bfffd326310156be270c6c1e56dc21d62 Adds `--summary` option to output `assembly_summary.tsv` and `taxonomy.tsv` only

## Changes 
* d16ce10f9a0c8c29b9f8009646b6d0811727023f Removes default sequence report download
* 45ff1bb4f9f5109aa74cc9338a2e79c893a0bd39 Bumps ncbi-datasets version
* fefa3899710162b6fa77f70f6bed6c8b11e01947 Updates help 